### PR TITLE
Hotfix s3 fs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "payer-mrf-streamsource"
 
-version := "0.3.5"
+version := "0.3.6"
 
 lazy val scala212 = "2.12.8"
 lazy val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "3.2.1")

--- a/src/main/scala/com/databricks/JsonMRFSource.scala
+++ b/src/main/scala/com/databricks/JsonMRFSource.scala
@@ -39,7 +39,8 @@ class JsonMRFSource (sqlContext: SQLContext, options: Map[String, String]) exten
       println("Conf --> setting filesystem to fs.s3a.S3AFileSystem")
       hadoopConf.set("fs.s3a.impl","org.apache.hadoop.fs.s3a.S3AFileSystem")
       hadoopConf.set("fs.s3.aws.credentials.provider", "com.amazonaws.auth.EnvironmentVariableCredentialsProvider")
-      FileSystem.get(hadoopConf)
+      val p = new Path(options.get("uncompressedPath").get)
+      p.getFileSystem(hadoopConf)
     case _ =>  FileSystem.get(hadoopConf)
   }
   val fileName = new Path(options.get("uncompressedPath").get)

--- a/src/test/scala/com/databricks/SparkStreamingSource.scala
+++ b/src/test/scala/com/databricks/SparkStreamingSource.scala
@@ -37,6 +37,7 @@ class SparkStreamingSource extends BaseTest with BeforeAndAfter{
   test("TST02-Results are all valid JSON objects"){
     val df = ( spark.readStream
       .format("payer-mrf")
+      .option("filesystem", "s3a")
       .load("src/test/resources/in-network-rates-fee-for-service-single-plan-sample.json")
     )
 


### PR DESCRIPTION
Updating how the Filesystem is created in S3. Add option param below to invoke this. 

fixes #27 

``` scala
.option("filesystem", "s3a") 
```