### PR TITLE
use current hadoopConfiguration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "payer-mrf-streamsource"
 
-version := "0.3.7"
+version := "0.3.8"
 
 lazy val scala212 = "2.12.8"
 lazy val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "3.5.0")

--- a/src/main/scala/com/databricks/JsonChunks.scala
+++ b/src/main/scala/com/databricks/JsonChunks.scala
@@ -108,16 +108,16 @@ private class JsonMRFRDD(
 
 
 object JsonMRFRDD{
-  var fs: FileSystem = null
   def open(serHadoopConfig: SerializableConfiguration, options: Map[String, String], fileName: Path ) = {
     val hadoopConfig = serHadoopConfig.value
-    if (fs == null) {
-      fs = options.get("filesystem") match {
+    val fs = options.get("filesystem") match {
+        case Some("s3") => FileSystem.get(URI.create(options.get("uncompressedPath").get), hadoopConfig);
         case Some("s3a") => FileSystem.get(URI.create(options.get("uncompressedPath").get), hadoopConfig);
         case Some("abfss") => FileSystem.get(URI.create(options.get("uncompressedPath").get), hadoopConfig);
-        case _ => FileSystem.get(hadoopConfig)
+        case Some("gs") => FileSystem.get(URI.create(options.get("uncompressedPath").get), hadoopConfig);
+        case Some("dbfs") => FileSystem.get(URI.create(options.get("uncompressedPath").get), hadoopConfig);
+        case _ =>  FileSystem.get(URI.create("file:/"), hadoopConfig);
       }
-    }
     fs.open(fileName)
   }
 }

--- a/src/main/scala/com/databricks/JsonChunks.scala
+++ b/src/main/scala/com/databricks/JsonChunks.scala
@@ -8,8 +8,10 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.util.SerializableConfiguration
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 
+import java.net.URI
 import java.nio.charset.StandardCharsets
 
 case class JsonPartition(start: Long, end: Long,  headerKey: String = "", idx: Int = 0 ) extends Partition{
@@ -22,6 +24,8 @@ case class JsonPartition(start: Long, end: Long,  headerKey: String = "", idx: I
 private class JsonMRFRDD(
   sc: SparkContext,
   partitions: Array[JsonPartition],
+  options: Map[String, String], 
+  hadoopConfiguration: SerializableConfiguration,
   fileName: Path,
   payloadAsArray: Boolean = false)
     extends RDD[InternalRow](sc, Nil) {
@@ -35,7 +39,7 @@ private class JsonMRFRDD(
   //Only ever returning one "row" with the iterator...
   //Maybe change this in the future to break apart the json object further into individual rows?
   override def compute(thePart: Partition, context: TaskContext): Iterator[InternalRow] =  {
-    val in = JsonMRFRDD.fs.open(fileName)
+    val in = JsonMRFRDD.open(hadoopConfiguration, options, fileName)
     //Close out fis, bufferinputstream objects, etc
     val part = thePart.asInstanceOf[JsonPartition]
     in.seek(part.start)
@@ -104,5 +108,16 @@ private class JsonMRFRDD(
 
 
 object JsonMRFRDD{
-  val fs = FileSystem.get(new Configuration)
+  var fs: FileSystem = null
+  def open(serHadoopConfig: SerializableConfiguration, options: Map[String, String], fileName: Path ) = {
+    val hadoopConfig = serHadoopConfig.value
+    if (fs == null) {
+      fs = options.get("filesystem") match {
+        case Some("s3a") => FileSystem.get(URI.create(options.get("uncompressedPath").get), hadoopConfig);
+        case Some("abfss") => FileSystem.get(URI.create(options.get("uncompressedPath").get), hadoopConfig);
+        case _ => FileSystem.get(hadoopConfig)
+      }
+    }
+    fs.open(fileName)
+  }
 }

--- a/src/main/scala/com/databricks/JsonMRFSource.scala
+++ b/src/main/scala/com/databricks/JsonMRFSource.scala
@@ -7,7 +7,9 @@ import org.apache.spark.sql.execution.LogicalRDD
 import org.apache.spark.sql.execution.streaming.{LongOffset, Offset, Source}
 import org.apache.spark.sql.types.{ArrayType, StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.util.SerializableConfiguration
 
+import java.net.URI
 import java.io.BufferedInputStream
 import scala.collection.mutable.ListBuffer
 
@@ -33,15 +35,16 @@ class JsonMRFSource (sqlContext: SQLContext, options: Map[String, String]) exten
     case _ => 268435456 //256MB default 
   }
   println("Using read buffer size of " + BufferSize)
-  val hadoopConf = sqlContext.sparkSession.sessionState.newHadoopConf()
-  val fs =  options.get("filesystem") match {
-    case Some("s3a") =>
+  val hadoopConf = sqlContext.sparkSession.sparkContext.hadoopConfiguration
+  val fs = options.get("filesystem") match {
+     case Some("s3a") =>
       println("Conf --> setting filesystem to fs.s3a.S3AFileSystem")
       hadoopConf.set("fs.s3a.impl","org.apache.hadoop.fs.s3a.S3AFileSystem")
       hadoopConf.set("fs.s3.aws.credentials.provider", "com.amazonaws.auth.EnvironmentVariableCredentialsProvider")
       val p = new Path(options.get("uncompressedPath").get)
       p.getFileSystem(hadoopConf)
-    case _ =>  FileSystem.get(hadoopConf)
+    case Some("abfss") => FileSystem.get(URI.create(options.get("uncompressedPath").get), hadoopConf);
+    case _ =>  FileSystem.get(URI.create("file:/"), hadoopConf);
   }
   val fileName = new Path(options.get("uncompressedPath").get)
   val fileStream = fs.open(fileName)
@@ -203,6 +206,8 @@ class JsonMRFSource (sqlContext: SQLContext, options: Map[String, String]) exten
     val catalystRows = new JsonMRFRDD(
       sqlContext.sparkContext,
       batches.par.filter{ case (_, idx) => idx >= s && idx <= e}.zipWithIndex.map({ case (v, idx2) => new JsonPartition(v._1.start, v._1.end, v._1.headerKey, idx2)}).toArray,
+      options,
+      new SerializableConfiguration(sqlContext.sparkSession.sparkContext.hadoopConfiguration),
       fileName,
       payloadAsArray
     )

--- a/src/main/scala/com/databricks/JsonMRFSource.scala
+++ b/src/main/scala/com/databricks/JsonMRFSource.scala
@@ -37,13 +37,16 @@ class JsonMRFSource (sqlContext: SQLContext, options: Map[String, String]) exten
   println("Using read buffer size of " + BufferSize)
   val hadoopConf = sqlContext.sparkSession.sparkContext.hadoopConfiguration
   val fs = options.get("filesystem") match {
-     case Some("s3a") =>
+    case Some("s3") => FileSystem.get(URI.create(options.get("uncompressedPath").get), hadoopConf);
+    case Some("s3a") =>
       println("Conf --> setting filesystem to fs.s3a.S3AFileSystem")
       hadoopConf.set("fs.s3a.impl","org.apache.hadoop.fs.s3a.S3AFileSystem")
       hadoopConf.set("fs.s3.aws.credentials.provider", "com.amazonaws.auth.EnvironmentVariableCredentialsProvider")
       val p = new Path(options.get("uncompressedPath").get)
       p.getFileSystem(hadoopConf)
     case Some("abfss") => FileSystem.get(URI.create(options.get("uncompressedPath").get), hadoopConf);
+    case Some("gs") => FileSystem.get(URI.create(options.get("uncompressedPath").get), hadoopConf);
+    case Some("dbfs") => FileSystem.get(URI.create(options.get("uncompressedPath").get), hadoopConf);
     case _ =>  FileSystem.get(URI.create("file:/"), hadoopConf);
   }
   val fileName = new Path(options.get("uncompressedPath").get)

--- a/src/main/scala/com/databricks/JsonMRFSourceProvider.scala
+++ b/src/main/scala/com/databricks/JsonMRFSourceProvider.scala
@@ -9,6 +9,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, SQLContext}
 
 import java.io.{BufferedInputStream, BufferedOutputStream}
+import java.net.URI
 import java.util.zip.GZIPInputStream
 
 class JsonMRFSourceProvider extends StreamSourceProvider with DataSourceRegister with StreamSinkProvider {
@@ -33,20 +34,21 @@ class JsonMRFSourceProvider extends StreamSourceProvider with DataSourceRegister
     providerName: String,
     parameters: Map[String, String]): Source = {
 
+    val filesystem_param = parameters.getOrElse("filesystem", parameters.get("path").get.split(":/")(0))
     val params = parameters.get("path").get match {
 
       case ext if ext.endsWith(".gz") =>
-        val fs = FileSystem.get(sqlContext.sparkSession.sessionState.newHadoopConf())
+        val fs = FileSystem.get(URI.create(ext), sqlContext.sparkSession.sparkContext.hadoopConfiguration)
         val inStream = new BufferedInputStream(new GZIPInputStream(fs.open(new Path(ext))), 268435456) //256MB
         val fileName = if (ext.dropRight(3).endsWith(".json")) ext.dropRight(3) else ext.dropRight(3)+".json"
         val outStream = new BufferedOutputStream(fs.create(new Path(fileName) ,true))
         ByteStreams.copy(inStream, outStream)
         inStream.close
         outStream.close
-        parameters  + ("uncompressedPath" -> ext.dropRight(3))
+        parameters  + ("uncompressedPath" -> ext.dropRight(3)) + ("filesystem" -> filesystem_param)
 
       case ext if ext.endsWith(".json") =>
-        parameters + ("uncompressedPath" -> ext)
+        parameters + ("uncompressedPath" -> ext) + ("filesystem" -> filesystem_param)
 
       case _ => throw new Exception("codec for file extension not implemented yet")
     }


### PR DESCRIPTION
This pull request enhances the way file systems are handled when reading JSON data in Spark, improving flexibility and reliability for cloud and local filesystems. The main improvements involve making file system selection explicit and configurable, updating how Hadoop configurations are passed and used, and ensuring compatibility with different storage backends like S3 and ABFS.

**File system configuration and selection:**

* Added explicit support for selecting the file system (e.g., S3, ABFS, local) through a new `filesystem` parameter, and ensured this is propagated throughout the codebase for consistent behavior. (`JsonMRFSourceProvider.scala`, `JsonMRFSource.scala`, `JsonChunks.scala`) [[1]](diffhunk://#diff-2fd5e5c630f966de7e642e5284f9fdeebd5ec2999e55348e3522acbb2b3cf2f9R37-R51) [[2]](diffhunk://#diff-2fd5e5c630f966de7e642e5284f9fdeebd5ec2999e55348e3522acbb2b3cf2f9R12) [[3]](diffhunk://#diff-c40d8dc0cdb25259f7dc4de1f78d8f97a7c809749f0b115dc9e271f072e4287cL36-R47) [[4]](diffhunk://#diff-d85633afdaf10917f1e732acc7fd9a1c98e1353672a234b1f6443fd8ae526abbR27-R28)
* Updated logic to construct the Hadoop `FileSystem` using the correct URI and configuration, supporting cloud storage paths and ensuring the right implementation is used for each backend. (`JsonMRFSourceProvider.scala`, `JsonMRFSource.scala`, `JsonChunks.scala`) [[1]](diffhunk://#diff-2fd5e5c630f966de7e642e5284f9fdeebd5ec2999e55348e3522acbb2b3cf2f9R37-R51) [[2]](diffhunk://#diff-c40d8dc0cdb25259f7dc4de1f78d8f97a7c809749f0b115dc9e271f072e4287cL36-R47) [[3]](diffhunk://#diff-d85633afdaf10917f1e732acc7fd9a1c98e1353672a234b1f6443fd8ae526abbL107-R122)

**Hadoop configuration handling:**

* Introduced `SerializableConfiguration` to safely pass Hadoop configuration to RDDs, improving serialization and task execution reliability. (`JsonChunks.scala`, `JsonMRFSource.scala`) [[1]](diffhunk://#diff-d85633afdaf10917f1e732acc7fd9a1c98e1353672a234b1f6443fd8ae526abbR11-R14) [[2]](diffhunk://#diff-c40d8dc0cdb25259f7dc4de1f78d8f97a7c809749f0b115dc9e271f072e4287cR10-R12) [[3]](diffhunk://#diff-d85633afdaf10917f1e732acc7fd9a1c98e1353672a234b1f6443fd8ae526abbR27-R28) [[4]](diffhunk://#diff-c40d8dc0cdb25259f7dc4de1f78d8f97a7c809749f0b115dc9e271f072e4287cR209-R210)

**Code robustness and extensibility:**

* Refactored file opening logic into a static `open` method in `JsonMRFRDD` that selects the correct file system and ensures a single instance per configuration, simplifying resource management and future extensibility. (`JsonChunks.scala`) [[1]](diffhunk://#diff-d85633afdaf10917f1e732acc7fd9a1c98e1353672a234b1f6443fd8ae526abbL107-R122) [[2]](diffhunk://#diff-d85633afdaf10917f1e732acc7fd9a1c98e1353672a234b1f6443fd8ae526abbL38-R42)

**Parameter propagation and consistency:**

* Ensured that all relevant file system and path parameters are consistently included and passed through to all components, reducing errors and improving maintainability. (`JsonMRFSourceProvider.scala`, `JsonMRFSource.scala`, `JsonChunks.scala`) [[1]](diffhunk://#diff-2fd5e5c630f966de7e642e5284f9fdeebd5ec2999e55348e3522acbb2b3cf2f9R37-R51) [[2]](diffhunk://#diff-c40d8dc0cdb25259f7dc4de1f78d8f97a7c809749f0b115dc9e271f072e4287cR209-R210) [[3]](diffhunk://#diff-d85633afdaf10917f1e732acc7fd9a1c98e1353672a234b1f6443fd8ae526abbR27-R28)

These changes collectively make the JSON ingestion pipeline more robust and adaptable to various storage backends, particularly in cloud environments.


This code change is not compatible yet with Volumes, but fixed the issue to read Auth from UC Credentials available in the cluster.
[payer-mrf-streamsource-0.3.8.jar.zip](https://github.com/user-attachments/files/23482884/payer-mrf-streamsource-0.3.8.jar.zip)
